### PR TITLE
ping the fqdn

### DIFF
--- a/kustomize/overlay/7.0/obdemo-bank/dev/deployment-patch.yaml
+++ b/kustomize/overlay/7.0/obdemo-bank/dev/deployment-patch.yaml
@@ -22,7 +22,7 @@
         - |
           until $(curl -X GET --output /dev/null --silent --head --fail -H "X-OpenIDM-Username: anonymous" \
           -H "X-OpenIDM-Password: anonymous" -H "X-OpenIDM-NoSession: true" \
-          http://idm.cdk.svc.cluster.local:80/openidm/info/ping)
+          $IAM_FQDN/openidm/info/ping)
           do
           echo "IDM not ready"
           sleep 10


### PR DESCRIPTION
Rather than use internal kube dns to ping idm for a health check. use the `IAM_FQDN` instead. This should fix the init problem for local development.