### PR TITLE
apply fixes

### DIFF
--- a/kustomize/overlay/7.0/obdemo-bank/dev/deployment-patch.yaml
+++ b/kustomize/overlay/7.0/obdemo-bank/dev/deployment-patch.yaml
@@ -1,8 +1,8 @@
 - op: add
   path: /spec/template/spec/initContainers
   value:
-    - name: cdk-initializer
-      image: eu.gcr.io/sbat-gcr-develop/securebanking/secureopenbanking-uk-fidc-initializer:latest
+    - name: iam-init
+      image: eu.gcr.io/sbat-gcr-release/securebanking/secureopenbanking-uk-fidc-initializer:latest
       imagePullPolicy: Always
       env:
       - name: OPEN_AM_PASSWORD
@@ -22,7 +22,7 @@
         - |
           until $(curl -X GET --output /dev/null --silent --head --fail -H "X-OpenIDM-Username: anonymous" \
           -H "X-OpenIDM-Password: anonymous" -H "X-OpenIDM-NoSession: true" \
-          $IAM_FQDN/openidm/info/ping)
+          https://$IAM_FQDN/openidm/info/ping)
           do
           echo "IDM not ready"
           sleep 10


### PR DESCRIPTION
Change the container name to `iam-init`
default the initializer to look for the release repository.
prefix the curl request with `https://`


https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer/issues/10
https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-demo/issues/25