### PR TITLE
Connect rs

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/01-ob-rs-metadata.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/01-ob-rs-metadata.json
@@ -1,8 +1,8 @@
 {
   "name" : "OB RS Metadata",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "http://obdemo-rs:8089",
-  "condition" : "${matches(request.uri.path, '^/rs/obRSDiscovery')}",
+  "baseURI" : "&{rs.url}",
+  "condition" : "${matches(request.uri.path, '^/rs/open-banking/discovery')}",
   "handler": {
     "type": "Chain",
     "config": {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/08-ob-account-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/08-ob-account-access.json
@@ -1,8 +1,8 @@
 {
   "name" : "OB Account Access",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "http://obdemo-rs:8089",
-  "condition" : "${matches(request.uri.path, '^/rs/openbanking/v3.1/accounts')}",
+  "baseURI" : "&{rs.url}",
+  "condition" : "${matches(request.uri.path, '^/rs/open-banking/v3.1/accounts')}",
   "capture" : [ "response", "request" ],
   "handler" : {
     "type" : "Chain",

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/12-ob-payment-submission.json
@@ -1,8 +1,8 @@
 {
   "name" : "OB Payment Submission",
   "auditService": "AuditService-OB-Route",
-  "baseURI" : "http://obdemo-rs:8089",
-  "condition" : "${matches(request.uri.path, '^/rs/openbanking/v3.1.*/domestic-payments$')}",
+  "baseURI" : "&{rs.url}",
+  "condition" : "${matches(request.uri.path, '^/rs/open-banking/v3.1.*/domestic-payments$')}",
   "heap": [
     {
       "name": "JwkSetSecretStore-ApiClientJwks",

--- a/kustomize/overlay/7.0/obdemo-bank/dev/configmap.yaml
+++ b/kustomize/overlay/7.0/obdemo-bank/dev/configmap.yaml
@@ -5,6 +5,8 @@ metadata:
 data:
   FQDN: obdemo.dev.forgerock.financial
   IAM_FQDN: iam.dev.forgerock.financial
+  RS_URL: http://securebanking-openbanking-uk-rs.dev.svc.cluster.local:8080
+  RCS_URL: http://securebanking-openbanking-uk-rcs.dev.svc.cluster.local:8080
   AM_REALM: alpha
   IG_CLIENT_ID: ig-client
   IG_CLIENT_SECRET: password


### PR DESCRIPTION
Add a new environment variables `RS_URL` and `RCS_URL` that references the internal kube dns address of their respective services.

Reference this address in the ig routes for rs.
Change the discovery endpoint to redirect to the real [rs simulator](https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/blob/86f4cd340a3a0c5ad45d44d407ac7ee554cc32ff/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryController.java#L69)
Apply similar change from `openbanking` to open-banking