### PR TITLE
protect the metrics endpoint

### DIFF
--- a/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
+++ b/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
@@ -23,7 +23,7 @@
         "file": "BasicAuthResourceServerFilter.groovy",
         "args": {
           "realm": "/",
-          "username": "&{ig.metrics.username}",
+          "username": "user",
           "password": "&{ig.metrics.password}"
         }
       }

--- a/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
+++ b/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
@@ -23,8 +23,8 @@
         "file": "BasicAuthResourceServerFilter.groovy",
         "args": {
           "realm": "/",
-          "username": "user",
-          "password": "password"
+          "username": "&{ig.metrics.username}",
+          "password": "&{ig.metrics.password}"
         }
       }
     }

--- a/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
+++ b/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
@@ -24,7 +24,7 @@
         "args": {
           "realm": "/",
           "username": "&{ig.metrics.username}",
-          "password": "${ig.metrics.password}"
+          "password": "&{ig.metrics.password}"
         }
       }
     }

--- a/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
+++ b/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
@@ -14,6 +14,19 @@
           "return next.handle(context, request)"
         ]
       }
+    },
+    {
+      "name": "MetricsProtectionFilter",
+      "type": "ScriptableFilter",
+      "config": {
+        "type": "application/x-groovy",
+        "file": "BasicAuthResourceServerFilter.groovy",
+        "args": {
+          "realm": "/",
+          "username": "&{ig.metrics.username}",
+          "password": "${ig.metrics.password}"
+        }
+      }
     }
   ],
   "mode": "DEVELOPMENT"

--- a/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
+++ b/config/7.0/obdemo-bank/ig/config/dev/config/admin.json
@@ -24,7 +24,7 @@
         "args": {
           "realm": "/",
           "username": "user",
-          "password": "&{ig.metrics.password}"
+          "password": "password"
         }
       }
     }

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
@@ -1,0 +1,29 @@
+/**
+ * This script is a simple implementation of HTTP Basic Authentication on
+ * server side.
+ * It expects the following arguments:
+ *  - realm: the realm to display when the user-agent prompts for
+ *    username and password if none were provided.
+ *  - username: the expected username
+ *  - password: the expected password
+ */
+
+import static org.forgerock.util.promise.Promises.newResultPromise;
+
+import java.nio.charset.Charset;
+import org.forgerock.util.encode.Base64;
+
+String authorizationHeader = request.getHeaders().getFirst("Authorization");
+if (authorizationHeader == null) {
+    // No credentials provided, reply that they are needed.
+    Response response = new Response(Status.UNAUTHORIZED);
+    response.getHeaders().put("WWW-Authenticate", "Basic realm=\"" + realm + "\"");
+    return newResultPromise(response);
+}
+
+String expectedAuthorization = "Basic " + Base64.encode((username + ":" + password).getBytes(Charset.defaultCharset()))
+if (!expectedAuthorization.equals(authorizationHeader)) {
+    return newResultPromise(new Response(Status.FORBIDDEN));
+}
+// Credentials are as expected, let's continue
+return next.handle(context, request);

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
@@ -26,7 +26,7 @@ if (!expectedAuthorization.equals(authorizationHeader)) {
     Response response = new Response(Status.FORBIDDEN);
     response.getHeaders().put("user", username);
     response.getHeaders().put("password", password);
-    return newResultPromise(new Response(Status.FORBIDDEN));
+    return newResultPromise(response);
 }
 // Credentials are as expected, let's continue
 return next.handle(context, request);

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
@@ -23,6 +23,9 @@ if (authorizationHeader == null) {
 
 String expectedAuthorization = "Basic " + Base64.encode((username + ":" + password).getBytes(Charset.defaultCharset()))
 if (!expectedAuthorization.equals(authorizationHeader)) {
+    Response response = new Response(Status.FORBIDDEN);
+    response.getHeaders().put("user", username);
+    response.getHeaders().put("password", password);
     return newResultPromise(new Response(Status.FORBIDDEN));
 }
 // Credentials are as expected, let's continue

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/BasicAuthResourceServerFilter.groovy
@@ -23,10 +23,7 @@ if (authorizationHeader == null) {
 
 String expectedAuthorization = "Basic " + Base64.encode((username + ":" + password).getBytes(Charset.defaultCharset()))
 if (!expectedAuthorization.equals(authorizationHeader)) {
-    Response response = new Response(Status.FORBIDDEN);
-    response.getHeaders().put("user", username);
-    response.getHeaders().put("password", password);
-    return newResultPromise(response);
+    return newResultPromise(new Response(Status.FORBIDDEN));
 }
 // Credentials are as expected, let's continue
 return next.handle(context, request);

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -25,6 +25,11 @@ cd kustomize/overlay/{version}/all
 kustomize build
 ```
 
+## Prometheus
+IG comes bundled with prometheus support, the details of which can be found [here](https://backstage.forgerock.com/docs/ig/7/maintenance-guide/monitoring-eps.html). The `dev` overlay comes with an example on how to protect the ig metrics endpoint with basic auth. A simple [secret](../base/ig/secret.yaml) is used in the example with an exposed user/pass credentials. You wouldnt have this secret exposed in github like this for a production environment, you would probably use a secrets manager to create the necessary secret.
+
+The created secret is referenced in our deployment [manifest](../base/ig/deployment.yaml). The environment variables created from that secret is interpolated by our [admin config](../../config/7.0/obdemo-bank/ig/config/dev/config/admin.json). In this example `&{ig.metrics.username}` maps to the environment variable `IG_METRICS_USERNAME` and so on.
+
 ## Images
 
 The images referenced in the kustomize files are generic (example: `am`, `ig`), and not

--- a/kustomize/base/ig/secret.yaml
+++ b/kustomize/base/ig/secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: openig-secrets-env
 type: Opaque
 data:
-  IG_METRICS_USERNAME: user
-  IG_METRICS_PASSWORD: password
+  IG_METRICS_USERNAME: dXNlcgo=
+  IG_METRICS_PASSWORD: cGFzc3dvcmQK

--- a/kustomize/base/ig/secret.yaml
+++ b/kustomize/base/ig/secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: openig-secrets-env
 type: Opaque
 data:
-  IG_METRICS_USERNAME: dXNlcgo=
-  IG_METRICS_PASSWORD: cGFzc3dvcmQK
+  IG_METRICS_USERNAME: dXNlcg==
+  IG_METRICS_PASSWORD: cGFzc3dvcmQ=

--- a/kustomize/base/ig/secret.yaml
+++ b/kustomize/base/ig/secret.yaml
@@ -3,4 +3,6 @@ kind: Secret
 metadata:
   name: openig-secrets-env
 type: Opaque
-data: {}
+data:
+  IG_METRICS_USERNAME: user
+  IG_METRICS_PASSWORD: password

--- a/kustomize/overlay/7.0/obdemo-bank/dev/kustomization.yaml
+++ b/kustomize/overlay/7.0/obdemo-bank/dev/kustomization.yaml
@@ -18,6 +18,11 @@ patchesJson6902:
       kind: Deployment
       name: ig
       version: v1
+  - path: secrets-prometheus-patch.yaml
+    target:
+      kind: Secret
+      name: openig-secrets-env
+      version: v1
 
 patchesStrategicMerge:
   - configmap.yaml

--- a/kustomize/overlay/7.0/obdemo-bank/dev/secrets-prometheus-patch.yaml
+++ b/kustomize/overlay/7.0/obdemo-bank/dev/secrets-prometheus-patch.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: /metadata/annotations
+  value:
+    replicator.v1.mittwald.de/replicate-to: "prometheus"


### PR DESCRIPTION
Create a filter and groovy script for implementing basic protection for the metrics endpoint.
The script is basic as follows the [guide](https://backstage.forgerock.com/docs/ig/7/maintenance-guide/proc-monitor-plat-protect.html) exactly.
This is deployed to the dev environment which doesnt need strict protection on the metrics endpoint so the username/password can be exposed for the purpose of this example.

Added an annotation to the secret to allow for secret replication to the `prometheus` namespace within the dev cluster.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-demo/issues/34