### PR TITLE
remove unneeded config

### DIFF
--- a/kustomize/overlay/7.0/obdemo-bank/dev/configmap.yaml
+++ b/kustomize/overlay/7.0/obdemo-bank/dev/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   FQDN: obdemo.dev.forgerock.financial
   IAM_FQDN: iam.dev.forgerock.financial
-  RS_URL: http://securebanking-openbanking-uk-rs.dev.svc.cluster.local:8080
+  RS_URL: http://securebanking-openbanking-uk-rs:8080
   AM_REALM: alpha
   IG_CLIENT_ID: ig-client
   IG_CLIENT_SECRET: password


### PR DESCRIPTION
IG does not have its own namespace. We do not need the config to point to a specific namespace