### PR TITLE
Change the field pemCert to x5c

### DIFF
--- a/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
@@ -175,8 +175,8 @@ if(publicKey instanceof RSAPublicKey){
 
 Response response = new Response(Status.OK)
 response.getHeaders().add("Content-Type","application/json");
-//response.setEntity(pemCert + pemKey);
-logger.debug("Final JSON " + JWKJson)
-response.setEntity(JWKJson)
+
+logger.debug("Final JSON " + JWKJsonResponse)
+response.setEntity(JWKJsonResponse)
 
 return response

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
@@ -154,25 +154,13 @@ X509Certificate issuedCert  = new JcaX509CertificateConverter().setProvider(BC_P
 issuedCert.verify(caCertificate.getPublicKey(), BC_PROVIDER);
 
 // Build response with cert and private key
-
-/*
-def pemCert = Base64.getUrlEncoder().encodeToString(issuedCert.getEncoded())
-def pemKey =  Base64.getUrlEncoder().encodeToString(issuedCertKeyPair.getPrivate().getEncoded())
-
-
-def responseObj = [
-        "x5c": pemCert,
-        "key": pemKey
-]
-*/
-
 // should be base64url encoded to delivery as a json response
 def pemCert = Base64.getUrlEncoder().encodeToString(issuedCert.getEncoded())
 def pemKey =  Base64.getUrlEncoder().encodeToString(issuedCertKeyPair.getPrivate().getEncoded())
 
 def responseObj = [
-        "pemCert"   : pemCert,
-        "pemKey"    : pemKey
+        "x5c"   : pemCert,
+        "key"    : pemKey
 ]
 
 responseJson = JsonOutput.toJson(responseObj);

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
@@ -186,7 +186,7 @@ if(publicKey instanceof RSAPublicKey){
 } else if (publicKey instanceof ECPublicKey){
     ECKey ecJWK = ECKey.parse(issuedCert)
 
-    ECKey.Builder builder = new RSAKey.Builder((ECPublicKey) issuedCertKeyPair.getPublic())
+    ECKey.Builder builder = new ECKey.Builder((ECPublicKey) issuedCertKeyPair.getPublic())
             .privateKey((ECPrivateKey) issuedCertKeyPair.getPrivate());
 
     List<com.nimbusds.jose.util.Base64> x5c = new ArrayList<>(ecJWK.getX509CertChain());

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/JwkmsIssueCert.groovy
@@ -207,7 +207,7 @@ if(publicKey instanceof RSAPublicKey){
 
 
 Response response = new Response(Status.OK)
-response.getHeaders().add("Content-Type","application/json");
+response.getHeaders().add("Content-Type","application/jwk+json");
 
 logger.debug("Final JSON " + JWKJsonResponse)
 response.setEntity(JWKJsonResponse)


### PR DESCRIPTION
- Changed the field `pemCert` to `x5c` in the response json to align with the standard
- Script: `JwkmIssueCert.groovy`
Issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-functional-tests/issues/2