### PR TITLE
48: Make deployment alway pull latest image

### DIFF
--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             name: platform-config
         #image: gcr.io/forgerock-io/ig/docker-build:7.0.0-af5592b
         image: ig
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /kube/liveness


### PR DESCRIPTION
Routes were not appearing in IG deployments. This was because the latest
images was not ALWAYS being pulled from gcr.

Issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-demo/issues/48