### PR TITLE
remove iam-init

### DIFF
--- a/kustomize/base/ig/deployment.yaml
+++ b/kustomize/base/ig/deployment.yaml
@@ -14,34 +14,6 @@ spec:
       labels:
         app: ig
     spec:
-      initContainers:
-      - name: iam-init
-        image: eu.gcr.io/sbat-gcr-develop/securebanking/secureopenbanking-uk-fidc-initializer:latest
-        imagePullPolicy: Always
-        env:
-        - name: OPEN_AM_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: am-env-secrets
-              key: AM_PASSWORDS_AMADMIN_CLEAR
-        - name: IAM_FQDN
-          valueFrom:
-            configMapKeyRef:
-              name: platform-config
-              key: IAM_FQDN
-        - name: REQUEST_BODY_PATH
-          value: config/
-        command: ["/bin/sh", "-c"]
-        args: 
-          - |
-            until $(curl -X GET --output /dev/null --silent --head --fail -H "X-OpenIDM-Username: anonymous" \
-            -H "X-OpenIDM-Password: anonymous" -H "X-OpenIDM-NoSession: true" \
-            https://$IAM_FQDN/openidm/info/ping)
-            do
-            echo "IDM not ready"
-            sleep 10
-            done
-            ./setup
       containers:
       - name: ig
         env:


### PR DESCRIPTION
Remove the init-container for the cdk configurator. it does not belong with IG.
The init container has been moved to a cronjob that runs with the cdk. pr: https://github.com/ForgeCloud/sbat-infra/pull/106

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer/issues/25