### PR TITLE
Fix iss jwtIssuer

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/70-ob-jwkms-rcs-signresponse.json
@@ -35,7 +35,7 @@
             "type": "application/x-groovy",
             "file": "JwkmsProcessRCSClaims.groovy",
             "args": {
-              "routeArgJwtIssuer": "forgerock-rcs",
+              "routeArgJwtIssuer": "secure-open-banking-rcs",
               "routeArgJwtValidity": 300
             }
           }


### PR DESCRIPTION
 - Changed the jwt payload signresponse argument Value `routeArgJwtIssuer` from forgerock-rcs to secure-open-banking-rcs