### PR TITLE
260: Fix all am urls in oauth2 well known to use IG urls

### DIFF
--- a/config/7.0/obdemo-bank/ig/scripts/groovy/WellKnownFilter.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/WellKnownFilter.groovy
@@ -2,10 +2,16 @@ next.handle(context, request).thenOnResult(response -> {
 
   def rspJson = response.entity.getJson();
 
-
-  rspJson.registration_endpoint = rspJson.registration_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
-  rspJson.token_endpoint = rspJson.token_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.introspection_endpoint = = rspJson.introspection_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.check_session_iframe = rspJson.check_session_iframe.replace(routeArgInternalUri,routeArgExternalUri)
   rspJson.issuer = rspJson.issuer.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.authorization_endpoint = rspJson.authorization_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.token_endpoint = rspJson.token_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.end_session_endpoint = rspJson.end_session_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.revocation_endpoint = rspJson.revocation_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.userinfo_endpoint = rspJson.userinfo_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.jwks_uri = rspJson.jwks.replace(routeArgInternalUri,routeArgExternalUri)
+  rspJson.registration_endpoint = rspJson.registration_endpoint.replace(routeArgInternalUri,routeArgExternalUri)
 
   response.setEntity(rspJson)
 


### PR DESCRIPTION
This is needed for conformance and also because am is not usable without the access token that is held by IG, so going direct to ig doesn't work.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/260