### PR TITLE
260: Add valid ig forwarded-for values for AS routes

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/02-ob-as-metadata.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/02-ob-as-metadata.json
@@ -16,7 +16,7 @@
             "messageType" : "REQUEST",
             "remove" : [ "host", "X-Forwarded-Host" ],
             "add" : {
-              "X-Forwarded-Host" : [ "&{identity.platform.fqdn}" ]
+              "X-Forwarded-Host" : [ "&{ig.fqdn}" ]
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/54-ob-token-endpoint.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/54-ob-token-endpoint.json
@@ -29,7 +29,7 @@
             ],
             "add": {
               "X-Forwarded-Host": [
-                "obdemo-iam.idhub.cc"
+                "&{ig.fqdn}"
               ]
             }
           }

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/99-ob-as.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/99-ob-as.json
@@ -16,7 +16,7 @@
             "messageType" : "REQUEST",
             "remove" : [ "host", "X-Forwarded-Host" ],
             "add" : {
-              "X-Forwarded-Host" : [ "&{identity.platform.fqdn}" ]
+              "X-Forwarded-Host" : [ "&{ig.fqdn}" ]
             }
           }
         }


### PR DESCRIPTION
Working through the audience issue with @christian-brindley. We might need to rely on x-forwarded header values in AM, to match aud values in client credential jwts... so this pr sets them to be obdemo.<env>.forgerock.financial, which is what Api Clients including the FAPI compliance suite will set their audience values to.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/260
