### PR TITLE
299: Update the ingress manifest

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/10-ob-account-consent.json
@@ -61,7 +61,7 @@
           }
         },
         {
-          "comment": "Check access token with AM",
+          "comment": "Extracts the access_token from the request header. Uses the resolver to resolve the access_token and validate the token claims. Checks that the token has the scopes required by the filter configuration. Injects the access_token info into the OAuth2Context.",
           "name" : "OAuth2ResourceServerFilter-OB",
           "type" : "OAuth2ResourceServerFilter",
           "config" : {
@@ -69,9 +69,11 @@
             "requireHttps" : false,
             "realm" : "OpenIG",
             "accessTokenResolver" : {
+              "comment": "Check certificate-bound OAuth 2.0 bearer tokens presented by clients use the same mTLS-authenticated HTTP connection",
               "type": "ConfirmationKeyVerifierAccessTokenResolver",
               "config": {
                 "delegate": {
+                  "comment":"resolve access tokens and retrieve metadata about the token. The endpoint typically returns the time until the token expires, the OAuth 2.0 scopes associated with the token, and potentially other information",
                   "name": "token-resolver-1",
                   "type": "TokenIntrospectionAccessTokenResolver",
                   "config": {
@@ -99,7 +101,7 @@
           }
         },
         {
-          "commment": "Prepare account consent for IDM",
+          "commment": "Prepare account consent for IDM - change request URL and add CREST action",
           "name": "ProcessAccountConsent",
           "type": "ScriptableFilter",
           "config": {
@@ -137,7 +139,7 @@
           }
         },
         {
-          "comment": "Add access token to IDM request",
+          "comment": "Obtain access token from authz server and add request's Authorization header",
           "type": "ClientCredentialsOAuth2ClientFilter",
           "config": {
             "clientId": "&{ig.client.id}",

--- a/kustomize/base/7.0/ingress/ingress.yaml
+++ b/kustomize/base/7.0/ingress/ingress.yaml
@@ -1,6 +1,6 @@
 # When K8S is upgraded to >= 1.14 - change the apiVersion to:
 #apiVersion: networking.k8s.io/v1beta1
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -23,37 +23,55 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: ig
-          servicePort: 8080
+          service:
+            name: ig
+            port:
+              number: 8080
         path: /am
+        pathType: Exact
       - backend:
-          serviceName: ig
-          servicePort: 8080
+          service:
+            name: ig
+            port:
+              number: 8080
         path: /rcs-api
+        pathType: Exact        
       - backend:
-          serviceName: ig
-          servicePort: 8080
+          service:
+            name: ig
+            port:
+              number: 8080
         path: /rs
+        pathType: Exact        
 # Temporary - this will be internal
       - backend:
-          serviceName: ig
-          servicePort: 8080
+          service:
+            name: ig
+            port:
+              number: 8080
         path: /repo
+        pathType: Exact        
 # Temporary - this will be internal
       - backend:
-          serviceName: ig
-          servicePort: 8080
+          service:
+            name: ig
+            port:
+              number: 8080
         path: /jwkms
+        pathType: Exact        
       - backend:
-          serviceName: ig
-          servicePort: 8080
+          service:
+            name: ig
+            port:
+              number: 8080
         path: /jwksproxy
+        pathType: Exact        
   tls:
   - hosts:
     - $(IG_FQDN)
     secretName: sslcert
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ig-web
@@ -72,6 +90,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: ig
-          servicePort: 8080
+          service:
+            name: ig
+            port:
+              number: 8080
         path: /ig(/|$)(.*)
+        pathType: Exact

--- a/kustomize/base/obdemo-bank/application.yaml
+++ b/kustomize/base/obdemo-bank/application.yaml
@@ -15,7 +15,7 @@ spec:
       kind: Service
     - group: apps
       kind: StatefulSet
-    - group: extensions/v1beta1
+    - group: networking.k8s.io/v1
       kind: Ingress
     - group: v1
       kind: Deployment


### PR DESCRIPTION
Later versions of kubernetes have done away with the old schema type for Ingress
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/299