### PR TITLE
Fix the x-ob-account-id header for Domestic Scheduled Payments

### DIFF
--- a/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/32-ob-payment-submission.json
@@ -172,18 +172,6 @@
           }
         },
         {
-          "comment": "Adjust URL for downstream resource server",
-          "name": "TranslatePaymentResource",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "TranslatePaymentResource.groovy",
-            "args": {
-              "accounts": "${contexts.jwtBuilder.value}"
-            }
-          }
-        },
-        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/33-ob-domestic-payments-access.json
@@ -150,18 +150,6 @@
           }
         },
         {
-          "comment": "Adjust URL for downstream resource server",
-          "name": "TranslatePaymentResource",
-          "type": "ScriptableFilter",
-          "config": {
-            "type": "application/x-groovy",
-            "file": "TranslatePaymentResource.groovy",
-            "args": {
-              "accounts": "${contexts.jwtBuilder.value}"
-            }
-          }
-        },
-        {
           "comment": "Prepare consent audit trail",
           "type": "ScriptableFilter",
           "config": {

--- a/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
+++ b/config/7.0/obdemo-bank/ig/routes/routes-service/36-ob-scheduled-payment-submission.json
@@ -13,6 +13,15 @@
     "config": {
       "filters": [
         {
+          "comment": "Modify Payment Intent Response",
+          "name": "ModifyPaymentIntentResponse",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "ModifyPaymentIntentResponse.groovy"
+          }
+        },
+        {
           "comment": "Add a detached signature to the response",
           "name": "AddDetachedSig",
           "type": "ScriptableFilter",
@@ -172,6 +181,20 @@
           }
         },
         {
+          "comment": "Fetch Open Banking consent from IDM to get the resource owner id",
+          "name": "GetResourceOwnerIdFromConsent",
+          "type": "ScriptableFilter",
+          "config": {
+            "type": "application/x-groovy",
+            "file": "GetResourceOwnerIdFromConsent.groovy",
+            "clientHandler": "IDMClientHandler",
+            "args": {
+              "routeArgIdmBaseUri": "https://&{identity.platform.fqdn}",
+              "routeArgObjUser": "&{user.object}"
+            }
+          }
+        },
+        {
           "comment": "Adjust URL for downstream resource server",
           "name": "TranslatePaymentResource",
           "type": "ScriptableFilter",
@@ -179,7 +202,7 @@
             "type": "application/x-groovy",
             "file": "TranslatePaymentResource.groovy",
             "args": {
-              "accounts": "${contexts.jwtBuilder.value}"
+              "routeArgAccountIdHeader": "x-ob-account-id"
             }
           }
         },

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ModifyPaymentIntentResponse.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ModifyPaymentIntentResponse.groovy
@@ -11,11 +11,10 @@ next.handle(context, request).thenOnResult({ response ->
         }
         catch(Exception e)
         {
-            logger.debug("Debtor Account's accountId is not set: " + responseBody)
+            logger.debug(SCRIPT_NAME + "Debtor Account's accountId is not set: " + responseBody)
         }
 
-        logger.debug("The payment intent without Debtor Account's accountId: " + responseBody)
+        logger.debug(SCRIPT_NAME + "The payment intent without Debtor Account's accountId: " + responseBody)
         response.setEntity(responseBody)
     }
-
 })

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessRs.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/ProcessRs.groovy
@@ -33,6 +33,12 @@ next.handle(context, request).thenOnResult(response -> {
             value.Links.linkValues.add("https://" + request.getHeaders().getFirst('X-Forwarded-Host') + "/rs/open-banking/" + value.Version.asString() + "/pisp/domestic-payment-consents/{ConsentId}");
             value.Links.links.add("GetDomesticPaymentConsentsConsentIdFundsConfirmation", "https://" + request.getHeaders().getFirst('X-Forwarded-Host') + "/rs/open-banking/" + value.Version.asString() + "/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation");
             value.Links.linkValues.add("https://" + request.getHeaders().getFirst('X-Forwarded-Host') + "/rs/open-banking/" + value.Version.asString() + "/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation");
+
+            //Domestic Scheduled Payments Consents
+            value.Links.links.add("CreateDomesticScheduledPaymentConsent", "https://" + request.getHeaders().getFirst('X-Forwarded-Host') + "/rs/open-banking/" + value.Version.asString() + "/pisp/domestic-scheduled-payment-consents");
+            value.Links.linkValues.add("https://" + request.getHeaders().getFirst('X-Forwarded-Host') + "/rs/open-banking/" + value.Version.asString() + "/pisp/domestic-scheduled-payment-consents");
+            value.Links.links.add("GetDomesticScheduledPaymentConsent", "https://" + request.getHeaders().getFirst('X-Forwarded-Host') + "/rs/open-banking/" + value.Version.asString() + "/pisp/domestic-scheduled-payment-consents/{ConsentId}");
+            value.Links.linkValues.add("https://" + request.getHeaders().getFirst('X-Forwarded-Host') + "/rs/open-banking/" + value.Version.asString() + "/pisp/domestic-scheduled-payment-consents/{ConsentId}");
         }
         newEntity.get("Data").remove("paymentInitiationAPI");
         newEntity.get("Data").add("paymentInitiationAPI", paymentInitiationAPI);

--- a/config/7.0/obdemo-bank/ig/scripts/groovy/TranslatePaymentResource.groovy
+++ b/config/7.0/obdemo-bank/ig/scripts/groovy/TranslatePaymentResource.groovy
@@ -1,3 +1,6 @@
+SCRIPT_NAME = "[TranslatePaymentResource] - "
+logger.debug(SCRIPT_NAME + " Running...")
 
-request.uri.path = request.uri.path.replaceFirst("/openbanking/.*?/","/")
+request.headers.add(routeArgAccountIdHeader, attributes.get("accountId"))
+
 next.handle(context, request)


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/312

### Implementation
- [x] In the GetResourceOwnerIdFromConsent.groovy script, we will get the accountId value from the intent and save it to the attributes list
- [x] In the TranslatePaymentResource.groovy script, we will get the accountId value from the attributes list, and add the value to the x-ob-account-id header
- [x] Remove the accountId from the Domestic Scheduled Payment Consent route using the script ModifyPaymentIntentResponse.groovy
- [x] Added the URLs for the Domestic Scheduled Consent to RS Discovery route:
```
* "GetDomesticScheduledPayment": "https://obdemo.<env>.forgerock.financial/rs/open-banking/v3.1.1/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}",
* "CreateDomesticScheduledPayment": "https://obdemo.<env>.forgerock.financial/rs/open-banking/v3.1.1/pisp/domestic-scheduled-payments"
```